### PR TITLE
Add Class Assertions for Multiple Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,15 @@ Check them out in the Livewire source in ['livewire/src/Features/SupportTesting/
 In addition, the package provides the following:
 ### assertMissingAllClasses
 Pass a selector, and an array of classes.  This checks that none of the classes in the array passed are present
+On failure, will return any classes that are present, that should not be
 
 ### assertHasAllClasses
 Pass a selector, and an array of classes.  This checks that the element has all classes present from the array (but may have others)
+On failure, will return any classes that are missing, that should be present
 
 ### assertHasOnlyClasses
 Pass a selector, and an array of classes.  This checks that the element has no additional classes to the array passed
+On failure, will return any classes that are present, that should not be
 
 ## Demo Package
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ Livewire comes with a bunch of Dusk macros which you can use.
 
 Check them out in the Livewire source in ['livewire/src/Features/SupportTesting/DuskBrowserMacros.php'](https://github.com/livewire/livewire/blob/main/src/Features/SupportTesting/DuskBrowserMacros.php).
 
+In addition, the package provides the following:
+### assertMissingAllClasses
+Pass a selector, and an array of classes.  This checks that none of the classes in the array passed are present
+
+### assertHasAllClasses
+Pass a selector, and an array of classes.  This checks that the element has all classes present from the array (but may have others)
+
+### assertHasOnlyClasses
+Pass a selector, and an array of classes.  This checks that the element has no additional classes to the array passed
+
 ## Demo Package
 
 A demo package has been setup which gives a sample of how this package can be used. Check it out here

--- a/src/LivewireDuskTestbenchServiceProvider.php
+++ b/src/LivewireDuskTestbenchServiceProvider.php
@@ -11,6 +11,46 @@ class LivewireDuskTestbenchServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+
+        Browser::macro('assertHasAllClasses', function (string $selector, array $contents = []) {
+            $fullSelector = $this->resolver->format($selector);
+
+            $invalidClasses = array_diff($contents, explode(' ', $this->attribute($selector, 'class')));
+            
+            PHPUnit::assertEmpty(
+                $invalidClasses,
+                "Element [{$fullSelector}] is missing required classes [".implode(" ", $invalidClasses)."]."
+            );
+
+            return $this;
+        });
+
+        Browser::macro('assertHasOnlyClasses', function (string $selector, array $contents = []) {
+            $fullSelector = $this->resolver->format($selector);
+
+            $invalidClasses = array_diff(explode(' ', $this->attribute($selector, 'class')), $contents);
+
+            PHPUnit::assertEmpty(
+                $invalidClasses,
+                "Element [{$fullSelector}] has classes that must not be present [".implode(" ", $invalidClasses)."]."
+            );
+
+            return $this;
+        });
+
+        Browser::macro('assertMissingAllClasses', function (string $selector, array $contents = []) {
+            $fullSelector = $this->resolver->format($selector);
+
+            $invalidClasses = array_intersect($contents, explode(' ', $this->attribute($selector, 'class')));
+
+            PHPUnit::assertEmpty(
+                $invalidClasses,
+                "Element [{$fullSelector}] has classes that must be missing [".implode(" ", $invalidClasses)."]."
+            );
+
+            return $this;
+        });
+
         Browser::macro('assertSeeInOrder', function ($selector, $contents) {
             $fullSelector = $this->resolver->format($selector);
 

--- a/tests/Browser/DuskBrowserMixinTest.php
+++ b/tests/Browser/DuskBrowserMixinTest.php
@@ -6,7 +6,7 @@ use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\AssertionFailedError;
 
-class DuskBrowserMixinsTest extends TestCase
+class DuskBrowserMixinTest extends TestCase
 {
     /** @test */
     public function assert_see_in_order_macro_passes()

--- a/tests/Browser/DuskBrowserMixinsTest.php
+++ b/tests/Browser/DuskBrowserMixinsTest.php
@@ -4,11 +4,12 @@ namespace LivewireDuskTestbench\Tests\Browser;
 
 use Livewire\Component;
 use Livewire\Livewire;
+use PHPUnit\Framework\AssertionFailedError;
 
 class DuskBrowserMixinsTest extends TestCase
 {
     /** @test */
-    public function assert_see_in_order_macro_works()
+    public function assert_see_in_order_macro_passes()
     {
         Livewire::visit(new class extends Component
         {
@@ -29,7 +30,30 @@ class DuskBrowserMixinsTest extends TestCase
     }
 
     /** @test */
-    public function assert_is_visibile_in_container_works()
+    public function assert_see_in_order_macro_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <ul dusk="list">
+                        <li>bob</li>
+                        <li>john</li>
+                        <li>bill</li>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+            ->assertSeeInOrder('@list', ['john', 'bob', 'bill']);
+    }
+
+    /** @test */
+    public function assert_is_visibile_in_container_passes()
     {
         Livewire::visit(new class extends Component
         {
@@ -50,7 +74,30 @@ class DuskBrowserMixinsTest extends TestCase
     }
 
     /** @test */
-    public function assert_is_not_visibile_in_container_works()
+    public function assert_is_visibile_in_container_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <ul style="height:10px" dusk="list">
+                        <li style="height:10px" dusk="bob">bob</li>
+                        <li style="height:10px" dusk="john">john</li>
+                        <li style="height:10px" dusk="bill">bill</li>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+            ->assertIsVisibleInContainer('@list', '@john');
+    }
+
+    /** @test */
+    public function assert_is_not_visibile_in_container_passes()
     {
         Livewire::visit(new class extends Component
         {
@@ -69,5 +116,136 @@ class DuskBrowserMixinsTest extends TestCase
         })
             ->assertIsNotVisibleInContainer('@list', '@john')
             ->assertIsNotVisibleInContainer('@list', '@bill');
+    }
+
+    /** @test */
+    public function assert_is_not_visibile_in_container_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <ul style="height:10px" dusk="list">
+                        <li style="height:10px" dusk="bob">bob</li>
+                        <li style="height:10px" dusk="john">john</li>
+                        <li style="height:10px" dusk="bill">bill</li>
+                    </ul>
+                </div>
+                HTML;
+            }
+        })
+            ->assertIsNotVisibleInContainer('@list', '@bob');
+    }
+
+    /** @test */
+    public function assert_has_classes_passes()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <p class="test other sample" dusk="item"></p>
+                </div>
+                HTML;
+            }
+        })
+            ->assertHasClasses('@item', ['test', 'other']);
+    }
+
+    /** @test */
+    public function assert_has_classes_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <p class="test sample" dusk="item"></p>
+                </div>
+                HTML;
+            }
+        })
+            ->assertHasClasses('@item', ['test', 'other']);
+    }
+
+    /** @test */
+    public function assert_has_only_classes_passes()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <p class="test other" dusk="item"></p>
+                </div>
+                HTML;
+            }
+        })
+            ->assertHasOnlyClasses('@item', ['test', 'other']);
+    }
+
+    /** @test */
+    public function assert_has_only_classes_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <p class="test other sample" dusk="item"></p>
+                </div>
+                HTML;
+            }
+        })
+            ->assertHasOnlyClasses('@item', ['test', 'other']);
+    }
+
+    /** @test */
+    public function assert_missing_classes_passes()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <p class="sample" dusk="item"></p>
+                </div>
+                HTML;
+            }
+        })
+            ->assertMissingClasses('@item', ['test', 'other']);
+    }
+
+    /** @test */
+    public function assert_missing_classes_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div>
+                    <p class="sample" dusk="item"></p>
+                </div>
+                HTML;
+            }
+        })
+            ->assertMissingClasses('@item', ['test', 'sample']);
     }
 }


### PR DESCRIPTION
Adds the following Macros for testing, specifically in relation to class presence/absence.

At present in Livewire Dusk core macros, only single classes can be targeted for presence/absence using assertHasClass and assertClassMissing

This adds three new methods that allow you to check if the element has none/all/only the classes passed to it, which should reduce the time to create tests

### assertMissingAllClasses
Pass a selector, and an array of classes.  This checks that none of the classes in the array passed are present
On failure, will return any classes that are present, that should not be

### assertHasAllClasses
Pass a selector, and an array of classes.  This checks that the element has all classes present from the array (but may have others)
On failure, will return any classes that are missing, that should be present

### assertHasOnlyClasses
Pass a selector, and an array of classes.  This checks that the element has no additional classes than present in the array passed to it
On failure, will return any classes that are present, that should not be
