### PR TITLE
Add console error assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ In addition, the package provides the following:
 - `assertHasClasses('@selector', ['class1', 'class2', 'class3'])`
 - `assertHasOnlyClasses('@selector', ['class1', 'class2', 'class3'])`
 - `assertMissingClasses('@selector', ['class1', 'class2', 'class3'])`
+- `assertConsoleLogHasErrors()`
+- `assertConsoleLogMissingErrors()`
+- `assertConsoleLogHasError($message)`
+- `assertConsoleLogMissingError($message)`
 
 ## Demo Package
 

--- a/src/DuskBrowserMixin.php
+++ b/src/DuskBrowserMixin.php
@@ -120,6 +120,102 @@ class DuskBrowserMixin
         };
     }
 
+    public function assertConsoleLogHasErrors()
+    {
+        return function ($includeFavicon = false) {
+            $logs = $this->driver->manage()->getLog('browser');
+
+            $containsError = false;
+
+            foreach ($logs as $log) {
+                if (! isset($log['message']) || ! isset($log['level']) || ($log['level'] !== 'ERROR' && $log['level'] !== 'SEVERE')) {
+                    continue;
+                }
+
+                // Ignore default favicon.ico error unless specified to include
+                if (! str($log['message'])->contains('favicon.ico') || $includeFavicon) {
+                    $containsError = true;
+                    break;
+                }
+            }
+
+            PHPUnit::assertTrue($containsError, 'Console log does not contain any error messages');
+
+            return $this;
+        };
+    }
+
+    public function assertConsoleLogMissingErrors()
+    {
+        return function ($includeFavicon = false) {
+            $logs = $this->driver->manage()->getLog('browser');
+
+            $containsError = false;
+
+            foreach ($logs as $log) {
+                if (! isset($log['message']) || ! isset($log['level']) || ($log['level'] !== 'ERROR' && $log['level'] !== 'SEVERE')) {
+                    continue;
+                }
+
+                // Ignore default favicon.ico error unless specified to include
+                if (! str($log['message'])->contains('favicon.ico') || $includeFavicon) {
+                    $containsError = true;
+                    break;
+                }
+            }
+
+            PHPUnit::assertFalse($containsError, 'Console log contains an error message');
+
+            return $this;
+        };
+    }
+
+    public function assertConsoleLogHasError()
+    {
+        return function ($expectedMessage) {
+            $logs = $this->driver->manage()->getLog('browser');
+
+            $containsError = false;
+
+            foreach ($logs as $log) {
+                if (! isset($log['message']) || ! isset($log['level']) || ($log['level'] !== 'ERROR' && $log['level'] !== 'SEVERE')) {
+                    continue;
+                }
+
+                if (str($log['message'])->contains($expectedMessage)) {
+                    $containsError = true;
+                }
+            }
+
+            PHPUnit::assertTrue($containsError, "Console log error message \"{$expectedMessage}\" was not found");
+
+            return $this;
+        };
+    }
+
+    public function assertConsoleLogMissingError()
+    {
+        return function ($expectedMessage) {
+            $logs = $this->driver->manage()->getLog('browser');
+
+            $containsError = false;
+
+            foreach ($logs as $log) {
+                if (! isset($log['message']) || ! isset($log['level']) || ($log['level'] !== 'ERROR' && $log['level'] !== 'SEVERE')) {
+                    continue;
+                }
+
+                if (str($log['message'])->contains($expectedMessage)) {
+                    $containsError = true;
+                }
+            }
+
+            PHPUnit::assertFalse($containsError, "Console log error message \"{$expectedMessage}\" was found");
+
+            return $this;
+        };
+    }
+
     protected function isVisibleScript()
     {
         return '

--- a/tests/Browser/DuskBrowserMixinTest.php
+++ b/tests/Browser/DuskBrowserMixinTest.php
@@ -248,4 +248,140 @@ class DuskBrowserMixinTest extends TestCase
         })
             ->assertMissingClasses('@item', ['test', 'sample']);
     }
+
+    /** @test */
+    public function assert_console_log_has_errors_passes()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div x-init="console.error('test')">
+                </div>
+                HTML;
+            }
+        })
+            ->assertConsoleLogHasErrors();
+    }
+
+    /** @test */
+    public function assert_console_log_has_errors_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div x-init="console.log('test')">
+                </div>
+                HTML;
+            }
+        })
+            ->assertConsoleLogHasErrors();
+    }
+
+    /** @test */
+    public function assert_console_log_missing_errors_passes()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div x-init="console.log('test')">
+                </div>
+                HTML;
+            }
+        })
+            ->assertConsoleLogMissingErrors();
+    }
+
+    /** @test */
+    public function assert_console_log_missing_errors_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div x-init="console.error('test')">
+                </div>
+                HTML;
+            }
+        })
+            ->assertConsoleLogMissingErrors();
+    }
+
+    /** @test */
+    public function assert_console_log_has_error_passes()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div x-init="console.error('test')">
+                </div>
+                HTML;
+            }
+        })
+            ->assertConsoleLogHasError('test');
+    }
+
+    /** @test */
+    public function assert_console_log_has_error_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div x-init="console.error('other')">
+                </div>
+                HTML;
+            }
+        })
+            ->assertConsoleLogHasError('test');
+    }
+
+    /** @test */
+    public function assert_console_log_missing_error_passes()
+    {
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div x-init="console.error('other')">
+                </div>
+                HTML;
+            }
+        })
+            ->assertConsoleLogMissingError('test');
+    }
+
+    /** @test */
+    public function assert_console_log_missing_error_fails()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        Livewire::visit(new class extends Component
+        {
+            public function render()
+            {
+                return <<< 'HTML'
+                <div x-init="console.error('test')">
+                </div>
+                HTML;
+            }
+        })
+            ->assertConsoleLogMissingError('test');
+    }
 }


### PR DESCRIPTION
This adds 4 new assertions:

- assertConsoleLogHasErrors()
- assertConsoleLogMissingErrors()
- assertConsoleLogHasError($message)
- assertConsoleLogMissingError($message)

Default favicon error message is filtered out of the first two assertions but can be included by passing `true` into them.

<img width="768" alt="image" src="https://github.com/user-attachments/assets/5be0321e-0ebe-4303-b9a1-8e2edad5c168">
